### PR TITLE
Add editorconfig to stop info.json reformatting

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[{info.json,*.py}]
+indent_size = 4


### PR DESCRIPTION
I keep reformatting `info.json` with 2 spaces instead of 4. This should stop it from happening (if you have the editorconfig plugin installed).